### PR TITLE
🐛 Don't error out when section exists as field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,12 @@ export default defineHook(
               const section = field.substring(0, underscoreIndex);
               const fieldName = field.substring(underscoreIndex + 1);
 
-              if (!organizedData[section]) organizedData[section] = {};
+              if (!organizedData[section]) {
+                organizedData[section] = {};
+              } else if (typeof organizedData[section] !== 'object') {
+                // section already exists as a field, make it an object
+                organizedData[section] = {_: organizedData[section]};
+              }
               organizedData[section][fieldName] = value;
             } else {
               organizedData[field] = value;


### PR DESCRIPTION
When a section already exists as a field Directus errors out. This means none of your collections can have overlapping fields and sections.

E.g. a collection with this data
```json
{
  "source": "google",
  "source_category": "news"
}
```
causes this error
```js
Error organizing sections: TypeError: Cannot create property 'category' on string 'google'
    at r (file:///directus/extensions/.registry/e5b0bfc6-cf84-403b-8d89-afba350d13fb/dist/index.js?t=1730888767112:1:59634)
[10:26:33.682] ERROR: Cannot create property 'category' on string 'google'
    err: {
      "type": "TypeError",
      "message": "Cannot create property 'category' on string 'google'",
      "stack":
          TypeError: Cannot create property 'category' on string 'google'
              at r (file:///directus/extensions/.registry/e5b0bfc6-cf84-403b-8d89-afba350d13fb/dist/index.js?t=1730888767112:1:59634)
    }
```

This change fixes that error and places the original value under an `_`:
```json
{
  "source": {
    "_": "google",
    "category": "news"
  }
}
```